### PR TITLE
ckanコンテナの起動方法を修正

### DIFF
--- a/pocs/open-data-poc/README.md
+++ b/pocs/open-data-poc/README.md
@@ -29,13 +29,6 @@ Creating orion-demo    ... done
 Creating cygnus-demo   ... done
 ```
 
-PostgreSQLが立ち上がるのに時間がかかるため、CKANの起動が失敗する。
-起動後数十秒待ち、CKANを再起動する。
-
-```bash
-$ docker-compose up -d
-```
-
 ## CKANユーザーの作成
 
 CygnusがCKANにデータを登録するために書き込み権限を持ったユーザーを作成する必要がある。
@@ -75,13 +68,7 @@ $ vim docker-compose.yml
       - CYGNUS_CKAN_ATTR_PERSISTENCE=row
 ```
 
-cygnus-demoコンテナを削除する。
-
-```bash
-$ docker-compose rm cygnus-demo
-```
-
-cygnus-demoコンテナを起動する。
+cygnus-demoコンテナを再起動する。
 
 ```bash
 $ docker-compose up -d

--- a/pocs/open-data-poc/ckan-demo/ckan/ckan-entrypoint.sh
+++ b/pocs/open-data-poc/ckan-demo/ckan/ckan-entrypoint.sh
@@ -54,11 +54,6 @@ add_plugin () {
     ckan-paster --plugin=ckan datastore set-permissions -c /etc/ckan/production.ini | psql -h postgres-demo -U postgres --set ON_ERROR_STOP=1
 }
 
-wait_starting_db () {
-  # TODO: Waiting for starting PostgreSQL
-  ls
-}
-
 # If we don't already have a config file, bootstrap
 if [ ! -e "$CONFIG" ]; then
   write_config

--- a/pocs/open-data-poc/ckan-demo/docker-compose.yml
+++ b/pocs/open-data-poc/ckan-demo/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - CKAN_SITE_URL=http://ckan-demo:5000
       - POSTGRES_PASSWORD=ckan
     privileged: true
+    restart: always
 
   postgres-demo:
     container_name: postgres-demo


### PR DESCRIPTION
ckanコンテナはPostgreSQLの起動を待たなければ起動できない。
Docker Composeのrestart機能を使用して、起動に失敗した場合は
自動的に再起動するように修正